### PR TITLE
gson 解析 适配后台接口返回null 导致APP 异常崩溃问题

### DIFF
--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/BooleanTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/BooleanTypeAdapter.java
@@ -1,0 +1,57 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * 部分后台会把boolean数据返回null, 并且服务器处理不好,客户端可以处理
+ *
+ */
+public class BooleanTypeAdapter extends TypeAdapter<Boolean> {
+    @Override
+    public void write(JsonWriter out, Boolean value) throws IOException {
+        try {
+            if (value == null){
+                value = false;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Boolean read(JsonReader in) throws IOException {
+        try {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a boolean");
+                return false;
+            }
+            if (in.peek() == JsonToken.NUMBER) {
+                Double value = in.nextDouble();
+                Log.e("TypeAdapter", value+ " is not a boolean");
+                return value == Double.valueOf(1) ? true : false;//boolean 有时候服务器给的是1，表示true，0可能就是false
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isFloatOrDouble(str)){
+                    return Double.valueOf(str)== Double.valueOf(1) ? true:false;
+                } else {
+                    Log.e("TypeAdapter", str + " is not a number");
+                }
+            }
+        }catch(NumberFormatException e){
+            Log.e("TypeAdapter", e.getMessage(), e);
+        } catch (Exception e) {
+            Log.e("TypeAdapter", e.getMessage(), e);
+        }
+        return false;
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/DoubleTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/DoubleTypeAdapter.java
@@ -1,0 +1,60 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * 部分服务器框架会把数字数据返回null, 并且服务器处理不好,客户端可以处理
+ */
+public class DoubleTypeAdapter extends TypeAdapter<Double> {
+    @Override
+    public void write(JsonWriter out, Double value) throws IOException {
+        try {
+            if (value == null){
+                value = 0D;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Double read(JsonReader in) throws IOException {
+        try {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a number");
+                return 0D;
+            }
+            if (in.peek() == JsonToken.BOOLEAN) {
+                boolean b = in.nextBoolean();
+                Log.e("TypeAdapter", b + " is not a number");
+                return 0D;
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isFloatOrDouble(str)){
+                    return Double.parseDouble(str);
+                } else {
+                    Log.e("TypeAdapter", str + " is not a number");
+                    return 0D;
+                }
+            } else {
+                Double value = in.nextDouble();
+                return value == null ? 0D : value;
+            }
+        }catch(NumberFormatException e){
+            Log.e("TypeAdapter", e.getMessage(), e);
+        } catch (Exception e) {
+            Log.e("TypeAdapter", e.getMessage(), e);
+        }
+        return 0D;
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/FloatTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/FloatTypeAdapter.java
@@ -1,0 +1,58 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+
+public class FloatTypeAdapter extends TypeAdapter<Float> {
+    @Override
+    public void write(JsonWriter out, Float value) throws IOException {
+        try {
+            if (value == null){
+                value = 0F;
+            }
+            out.value(value.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Float read(JsonReader in) throws IOException {
+        try {
+            Float value;
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a number");
+                return 0F;
+            }
+            if (in.peek() == JsonToken.BOOLEAN) {
+                boolean b = in.nextBoolean();
+                Log.e("TypeAdapter", b + " is not a number");
+                return 0F;
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isFloatOrDouble(str)){
+                    return Float.parseFloat(str);
+                } else {
+                    Log.e("TypeAdapter", str + " is not a number");
+                    return 0F;
+                }
+            } else {
+                String str = in.nextString();
+                value = Float.valueOf(str);
+            }
+            return value;
+        } catch (Exception e) {
+            Log.e("TypeAdapter", "Not a number", e);
+        }
+        return 0F;
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/IntegerTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/IntegerTypeAdapter.java
@@ -1,0 +1,58 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+
+public class IntegerTypeAdapter extends TypeAdapter<Integer> {
+
+    @Override
+    public void write(JsonWriter out, Integer value)throws IOException {
+        try {
+            if (value == null){
+                value = 0;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Integer read(JsonReader in)throws IOException {
+        try {
+            Integer value;
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a number");
+                return 0;
+            }
+            if (in.peek() == JsonToken.BOOLEAN) {
+                boolean b = in.nextBoolean();
+                Log.e("TypeAdapter", b + " is not a number");
+                return 0;
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isIntOrLong(str)){
+                    return Integer.parseInt(str);
+                } else {
+                    Log.e("TypeAdapter", str + " is not a int number");
+                    return 0;
+                }
+            } else {
+                value = in.nextInt();
+                return value;
+            }
+        } catch (Exception e) {
+            Log.e("TypeAdapter", "Not a number", e);
+        }
+        return 0;
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/LongTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/LongTypeAdapter.java
@@ -1,0 +1,59 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+
+public class LongTypeAdapter extends TypeAdapter<Long> {
+
+
+    @Override
+    public void write(JsonWriter out, Long value) throws IOException {
+        try {
+            if (value == null){
+                value = 0L;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Long read(JsonReader in) throws IOException {
+        try {
+            Long value;
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a number");
+                return 0L;
+            }
+            if (in.peek() == JsonToken.BOOLEAN) {
+                boolean b = in.nextBoolean();
+                Log.e("TypeAdapter", b + " is not a number");
+                return 0L;
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isIntOrLong(str)){
+                    return Long.parseLong(str);
+                } else {
+                    Log.e("TypeAdapter", str + " is not a int number");
+                    return 0L;
+                }
+            } else {
+                value = in.nextLong();
+                return value;
+            }
+        } catch (Exception e) {
+            Log.e("TypeAdapter", "Not a number", e);
+        }
+        return 0L;
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/NumberUtils.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/NumberUtils.java
@@ -1,0 +1,16 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.text.TextUtils;
+
+import java.util.regex.Pattern;
+
+public class NumberUtils {
+    public static boolean isIntOrLong(String str){
+        return TextUtils.isDigitsOnly(str);
+    }
+
+    public static boolean isFloatOrDouble(String str){
+        Pattern pattern = Pattern.compile("^[-\\+]?[.\\d]*$");
+        return pattern.matcher(str).matches();
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/StringTypeAdapter.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/gsontypeadapter/StringTypeAdapter.java
@@ -1,0 +1,43 @@
+package com.tcc.base.http.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * 部分服务器框架会把数字数据返回null, 并且服务器处理不好,客户端可以处理
+ */
+public class StringTypeAdapter extends TypeAdapter<String> {
+  
+    @Override
+    public void write(JsonWriter out, String value) throws IOException {
+        try {
+            if (value == null){
+                out.nullValue();
+                return;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        try {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a string");
+                return "";
+            }
+        } catch (Exception e) {
+            Log.e("TypeAdapter", "Not a String", e);
+        }
+        return in.nextString();
+    }
+}

--- a/rxhttp/src/main/java/rxhttp/wrapper/utils/GsonUtil.java
+++ b/rxhttp/src/main/java/rxhttp/wrapper/utils/GsonUtil.java
@@ -65,11 +65,18 @@ public class GsonUtil {
         if (gson == null) {
             gson = new GsonBuilder()
                 .disableHtmlEscaping()
-                .registerTypeAdapter(String.class, new StringAdapter())
-                .registerTypeAdapter(Integer.class, new IntegerDefault0Adapter())
-                .registerTypeAdapter(Double.class, new DoubleDefault0Adapter())
-                .registerTypeAdapter(Long.class, new LongDefault0Adapter())
-                .create();
+                    .registerTypeAdapter(Integer.class, new IntegerTypeAdapter())
+                    .registerTypeAdapter(int.class, new IntegerTypeAdapter())
+                    .registerTypeAdapter(Double.class, new DoubleTypeAdapter())
+                    .registerTypeAdapter(double.class, new DoubleTypeAdapter())
+                    .registerTypeAdapter(Long.class, new LongTypeAdapter())
+                    .registerTypeAdapter(long.class, new LongTypeAdapter())
+                    .registerTypeAdapter(Float.class, new FloatTypeAdapter())
+                    .registerTypeAdapter(float.class, new FloatTypeAdapter())
+                    .registerTypeAdapter(Boolean.class, new BooleanTypeAdapter())
+                    .registerTypeAdapter(boolean.class, new BooleanTypeAdapter())
+                    .registerTypeAdapter(String.class, new StringTypeAdapter())
+                    .create();
         }
         return gson;
     }


### PR DESCRIPTION
有些接口返回的字段 是 null ，解析成bean后，在调用bean的属性为null的时候，有时候会导致APP 崩溃